### PR TITLE
Improve accessiblity of frontpage subscription input and button

### DIFF
--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -91,17 +91,20 @@ export default component$(() => {
 							Be the first to know about exclusive offers & deals.
 						</p>
 						<div className="mt-4 sm:flex sm:max-w-md">
-							<label className="sr-only">Email address</label>
+							<label id="email-subscription" className="sr-only">
+								Email address
+							</label>
 							<input
 								type="email"
 								autoComplete="email"
 								required
 								className="appearance-none min-w-0 w-full bg-white border border-gray-300 rounded-md py-2 px-4 text-base text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white focus:border-white focus:placeholder-gray-400"
 								placeholder="Enter your email"
+								aria-labelledby="email-subscription"
 							/>
 							<div className="mt-3 rounded-md sm:mt-0 sm:ml-3 sm:flex-shrink-0">
 								<button
-									className="w-full border border-transparent rounded-md py-2 px-4 flex items-center justify-center text-base font-medium text-white bg-primary-500 hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-primary-500"
+									className="w-full border border-transparent rounded-md py-2 px-4 flex items-center justify-center text-base font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-primary-500"
 									onClick$={() => {}}
 								>
 									Subscribe


### PR DESCRIPTION
Fixes #21 

Sets label for email subscription using aria-describedby attribute and id on label.
Adjusts tailwind CSS colors on subscription button up one notch (+100) on regular and hover states:

<img width="338" alt="Screen Shot 2022-12-01 at 8 07 54 PM" src="https://user-images.githubusercontent.com/3682072/205192343-c2f043cf-79d4-49e0-845b-436c05d42fdf.png">

Before:
<img width="434" alt="Screen Shot 2022-12-01 at 8 11 48 PM" src="https://user-images.githubusercontent.com/3682072/205192393-5abc3e69-dc23-4ab6-9535-14c1cca29526.png">


After:
<img width="447" alt="Screen Shot 2022-12-01 at 8 11 38 PM" src="https://user-images.githubusercontent.com/3682072/205192404-0ce39eb9-fd37-42f4-875a-742689d7633d.png">
