### PR TITLE
Add alt attribute to Product and Collection Img tags

### DIFF
--- a/src/components/collection-card/CollectionCard.tsx
+++ b/src/components/collection-card/CollectionCard.tsx
@@ -17,6 +17,7 @@ export default component$(({ collection }: IProps) => {
 							height="300"
 							loading="lazy"
 							decoding="async"
+							alt={collection.name}
 						/>
 					</div>
 				</span>

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -8,7 +8,7 @@ export default component$(
 			<Link className="flex flex-col" href={`/products/${slug}`}>
 				<img
 					className="rounded-xl flex-grow object-cover aspect-[7/8]"
-					alt=""
+					alt={productName}
 					src={productAsset?.preview + '?w=300&h=400'}
 					width="300"
 					height="400"


### PR DESCRIPTION
Fixes #19

Adds alt attributes to `Img` tags on Product and Collection components.

Before:
<img width="752" alt="Screen Shot 2022-12-01 at 8 35 39 PM" src="https://user-images.githubusercontent.com/3682072/205194885-49a9eeef-5175-459d-8dd0-c7936545560b.png">

After:
<img width="731" alt="Screen Shot 2022-12-01 at 8 35 23 PM" src="https://user-images.githubusercontent.com/3682072/205194923-5ad2c11c-b913-4cd5-8ffe-f45adc027655.png">

