### PR TITLE
Extract input and button classes to global.css

### DIFF
--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -98,15 +98,12 @@ export default component$(() => {
 								type="email"
 								autoComplete="email"
 								required
-								className="appearance-none min-w-0 w-full bg-white border border-gray-300 rounded-md py-2 px-4 text-base text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white focus:border-white focus:placeholder-gray-400"
+								className="input-text"
 								placeholder="Enter your email"
 								aria-labelledby="email-subscription"
 							/>
 							<div className="mt-3 rounded-md sm:mt-0 sm:ml-3 sm:flex-shrink-0">
-								<button
-									className="w-full border border-transparent rounded-md py-2 px-4 flex items-center justify-center text-base font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-primary-500"
-									onClick$={() => {}}
-								>
+								<button className="btn-primary" onClick$={() => {}}>
 									Subscribe
 								</button>
 							</div>

--- a/src/global.css
+++ b/src/global.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+	.btn-primary {
+		@apply w-full border border-transparent rounded-md py-2 px-4 flex items-center justify-center text-base font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-primary-500;
+	}
+
+	.input-text {
+		@apply appearance-none min-w-0 w-full bg-white border border-gray-300 rounded-md py-2 px-4 text-base text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white focus:border-white focus:placeholder-gray-400;
+	}
+}


### PR DESCRIPTION
Finishes follow-up task from #21 by extracting tailwind classes to shared button and input classes in global.css