### PR TITLE
Support AVIF and WebP images via picture & source tags

### DIFF
--- a/src/components/collection-card/CollectionCard.tsx
+++ b/src/components/collection-card/CollectionCard.tsx
@@ -11,12 +11,24 @@ export default component$(({ collection }: IProps) => {
 			<div class="max-w-[300px] relative rounded-lg overflow-hidden hover:opacity-75 xl:w-auto mx-auto">
 				<span class="">
 					<div class="w-full h-full object-center object-cover">
-						<img
-							src={collection.featuredAsset?.preview + '?w=300&h=300'}
-							width="300"
-							height="300"
-							alt={collection.name}
-						/>
+						<picture>
+							<source
+								srcSet={collection.featuredAsset?.preview + '?w=300&h=300&format=avif'}
+								type="image/webp"
+							/>
+							<source
+								srcSet={collection.featuredAsset?.preview + '?w=300&h=300&format=webp'}
+								type="image/webp"
+							/>
+							<img
+								src={collection.featuredAsset?.preview + '?w=300&h=300'}
+								width="300"
+								height="300"
+								loading="lazy"
+								decoding="async"
+								alt={collection.name}
+							/>
+						</picture>
 					</div>
 				</span>
 				<span class="absolute w-full bottom-x-0 bottom-0 h-2/3 bg-gradient-to-t from-gray-800 opacity-50" />

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -5,13 +5,19 @@ export default component$(
 	({ productAsset, productName, slug, priceWithTax, currencyCode }: any) => {
 		return (
 			<a class="flex flex-col mx-auto" href={`/products/${slug}/`}>
-				<img
-					class="rounded-xl flex-grow object-cover aspect-[7/8]"
-					alt={productName}
-					src={productAsset?.preview + '?w=300&h=400'}
-					width="300"
-					height="400"
-				/>
+				<picture>
+					<source srcSet={productAsset?.preview + '?w=300&h=400&format=avif'} type="image/webp" />
+					<source srcSet={productAsset?.preview + '?w=300&h=400&format=webp'} type="image/webp" />
+					<img
+						class="rounded-xl flex-grow object-cover aspect-[7/8]"
+						alt={productName}
+						src={productAsset?.preview + '?w=300&h=400'}
+						width="300"
+						height="400"
+						loading="lazy"
+						decoding="async"
+					/>
+				</picture>
 				<div class="h-2" />
 				<div class="text-sm text-gray-700">{productName}</div>
 				<Price

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,13 +12,56 @@ export default component$(() => {
 			<div class="relative">
 				<div class="absolute inset-0 overflow-hidden">
 					{headerImage && (
-						<img
-							class="h-[565px] object-cover md:w-full"
-							src={headerImage + '?w=800&h=565'}
-							alt="header"
-							width="800"
-							height="565"
-						/>
+						<picture>
+							<source
+								srcSet={headerImage + '?w=1000&format=avif'}
+								type="image/avif"
+								media="(min-width: 1000px)"
+							/>
+							<source
+								srcSet={headerImage + '?w=800&format=avif'}
+								type="image/avif"
+								media="(min-width: 800px)"
+							/>
+							<source
+								srcSet={headerImage + '?w=600&format=avif'}
+								type="image/avif"
+								media="(min-width: 600px)"
+							/>
+							<source
+								srcSet={headerImage + '?w=400&format=avif'}
+								type="image/avif"
+								media="(min-width: 400px)"
+							/>
+							<source
+								srcSet={headerImage + '?w=1000&format=webp'}
+								type="image/webp"
+								media="(min-width: 1000px)"
+							/>
+							<source
+								srcSet={headerImage + '?w=800&format=webp'}
+								type="image/webp"
+								media="(min-width: 800px)"
+							/>
+							<source
+								srcSet={headerImage + '?w=600&format=webp'}
+								type="image/webp"
+								media="(min-width: 600px)"
+							/>
+							<source
+								srcSet={headerImage + '?w=400&format=webp'}
+								type="image/webp"
+								media="(min-width: 400px)"
+							/>
+							<img
+								class="h-full object-cover md:w-full"
+								src={headerImage + '?w=800'}
+								alt="Background header photo of bicycle taken by Mikkel Bech"
+								width="100%"
+								loading="lazy"
+								decoding="async"
+							/>
+						</picture>
 					)}
 					<div class="absolute inset-0 bg-gradient-to-br from-blue-500 to-indigo-700 mix-blend-overlay" />
 				</div>

--- a/src/routes/products/[...slug]/index.tsx
+++ b/src/routes/products/[...slug]/index.tsx
@@ -90,13 +90,21 @@ export default component$(() => {
 								<div class="w-full max-w-2xl mx-auto sm:block lg:max-w-none">
 									<span class="rounded-md overflow-hidden">
 										<div class="h-[400px] w-full md:w-[400px]">
-											<img
-												src={state.product.featuredAsset.preview + '?w=400&h=400'}
-												alt={state.product.name}
-												class="object-center object-cover rounded-lg"
-												width="400"
-												height="400"
-											/>
+											<picture>
+												<source
+													srcSet={state.product.featuredAsset.preview + '?w=400&h=400&format=webp'}
+													type="image/webp"
+												/>
+												<img
+													src={state.product.featuredAsset.preview + '?w=400&h=400'}
+													alt={state.product.name}
+													class="object-center object-cover rounded-lg"
+													width="400"
+													height="400"
+													loading="lazy"
+													decoding="async"
+												/>
+											</picture>
 										</div>
 									</span>
 								</div>


### PR DESCRIPTION
Adds responsive image loading for front page bicycle header image based on client screensize. Adds alt text for A11y.
Adds additional sources to all images supporting AVIF and WebP.

Reduces overall image weight on front page:
178KB -> 87KB (Including a larger header image at 1000px)

Electronics Category page:
332KB -> 153KB

Also, this removes the additional gap (which I'm not sure was by design?), that shows on larger breakpoints:
<img width="1101" alt="Screen Shot 2022-12-05 at 3 24 56 PM" src="https://user-images.githubusercontent.com/3682072/205736740-87018b32-133d-433b-8dfc-841efa361278.png">

Also adds back `loading="lazy"` and `decoding="async"` attributes since after profiling I didn't see specific CLS improvements when removed. @gioboa, could you weigh in?