### PR TITLE
Fix layout shift caused by account link render in header

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -28,7 +28,7 @@ export default component$(() => {
 				class={`bg-gradient-to-r from-blue-700 to-indigo-900 shadow-lg transform shadow-xl sticky top-0 z-10 animate-dropIn`}
 			>
 				<div class="bg-zinc-100 text-gray-600 shadow-inner text-center text-sm py-1 px-2 xl:px-0">
-					<div class="max-w-6xl mx-2 md:mx-auto flex items-center justify-between">
+					<div class="max-w-6xl mx-2 h-5 min-h-full md:mx-auto flex items-center justify-between">
 						<div>
 							<p class="hidden sm:block">
 								Exclusive: Get your own{' '}


### PR DESCRIPTION
Sets height for first header containing link to template and account link.

Before:
<table><tr><td>
<img width="198" alt="Screen Shot 2022-12-05 at 3 48 29 PM" src="https://user-images.githubusercontent.com/3682072/205740434-f49caa9b-916a-4314-873b-48ba5bf86f1a.png">
</td><td>
<img width="501" alt="Screen Shot 2022-12-05 at 3 48 44 PM" src="https://user-images.githubusercontent.com/3682072/205740474-3e425f0e-41b9-4c82-a5ee-1ff6cf7e76db.png">
</td><td>
<img width="343" alt="Screen Shot 2022-12-05 at 3 49 03 PM" src="https://user-images.githubusercontent.com/3682072/205740497-ee1b91de-dc95-4260-8f9d-62810f5b10ec.png">|
</td></tr></table>

After:
<img width="206" alt="Screen Shot 2022-12-05 at 3 47 51 PM" src="https://user-images.githubusercontent.com/3682072/205740763-f328d0c3-ef25-4446-9320-5234fd3875ca.png">
