### PR TITLE
Add resource hint to preconnect to demo.vendure.io

### DIFF
--- a/src/components/head/head.tsx
+++ b/src/components/head/head.tsx
@@ -13,7 +13,7 @@ export const Head = component$(() => {
 			<meta name="viewport" content="width=device-width, initial-scale=1" />
 			<meta name="description" content="Vendure Qwik Storefront" />
 			<title>Vendure Qwik Storefront</title>
-
+			<link rel="preconnect" href="https://demo.vendure.io" />
 			<link rel="canonical" href={loc.href} />
 
 			{head.meta.map((m) => (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,7 +3,7 @@ import CollectionCard from '~/components/collection-card/CollectionCard';
 import { APP_STATE } from '~/constants';
 
 export const headerImage =
-	'https://readonlydemo.vendure.io/assets/preview/2f/mikkel-bech-748940-unsplash__preview.jpg';
+	'https://demo.vendure.io/assets/preview/2f/mikkel-bech-748940-unsplash__preview.jpg';
 
 export default component$(() => {
 	const collections = useContext(APP_STATE).collections;


### PR DESCRIPTION
Adds preconnect link to demo.vendure.io initialize connection for API and image loads. Difficult to measure perf impact on local, will likely need to measure after a merge to prod.

Currenly seeing initial connection times to domain from 380ms to 600ms.