### PR TITLE
Remove lazy loaded image on front page affecting LCP

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -58,8 +58,6 @@ export default component$(() => {
 								src={headerImage + '?w=800'}
 								alt="Background header photo of bicycle taken by Mikkel Bech"
 								width="100%"
-								loading="lazy"
-								decoding="async"
 							/>
 						</picture>
 					)}


### PR DESCRIPTION
Fix regression in LCP metrics by adding `loading="lazy"` and `decoding="async"` to front page header image.

<img width="961" alt="Screen Shot 2022-12-05 at 4 56 05 PM" src="https://user-images.githubusercontent.com/3682072/205750790-315d1b36-a318-476f-96b9-9631269b8b34.png">
