### PR TITLE
Remove lazy load img from ComponentsCard

### DIFF
--- a/src/components/collection-card/CollectionCard.tsx
+++ b/src/components/collection-card/CollectionCard.tsx
@@ -24,8 +24,6 @@ export default component$(({ collection }: IProps) => {
 								src={collection.featuredAsset?.preview + '?w=300&h=300'}
 								width="300"
 								height="300"
-								loading="lazy"
-								decoding="async"
 								alt={collection.name}
 							/>
 						</picture>


### PR DESCRIPTION
Fixes overzealous re-addition of lazy loading attributes above the fold on the collections page:

![Uploading Screen Shot 2022-12-05 at 5.35.09 PM.png…]()
