### PR TITLE
Fix a few new AVIF and WebP image type bugs

### DIFF
--- a/src/components/collection-card/CollectionCard.tsx
+++ b/src/components/collection-card/CollectionCard.tsx
@@ -14,7 +14,7 @@ export default component$(({ collection }: IProps) => {
 						<picture>
 							<source
 								srcSet={collection.featuredAsset?.preview + '?w=300&h=300&format=avif'}
-								type="image/webp"
+								type="image/avif"
 							/>
 							<source
 								srcSet={collection.featuredAsset?.preview + '?w=300&h=300&format=webp'}

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -6,7 +6,7 @@ export default component$(
 		return (
 			<a class="flex flex-col mx-auto" href={`/products/${slug}/`}>
 				<picture>
-					<source srcSet={productAsset?.preview + '?w=300&h=400&format=avif'} type="image/webp" />
+					<source srcSet={productAsset?.preview + '?w=300&h=400&format=avif'} type="image/avif" />
 					<source srcSet={productAsset?.preview + '?w=300&h=400&format=webp'} type="image/webp" />
 					<img
 						class="rounded-xl flex-grow object-cover aspect-[7/8]"

--- a/src/routes/products/[...slug]/index.tsx
+++ b/src/routes/products/[...slug]/index.tsx
@@ -92,6 +92,10 @@ export default component$(() => {
 										<div class="h-[400px] w-full md:w-[400px]">
 											<picture>
 												<source
+													srcSet={state.product.featuredAsset.preview + '?w=400&h=400&format=avif'}
+													type="image/avif"
+												/>
+												<source
 													srcSet={state.product.featuredAsset.preview + '?w=400&h=400&format=webp'}
 													type="image/webp"
 												/>


### PR DESCRIPTION
Fix a few new AVIF and WebP image type bugs. `type="image/avif"` was incorrectly `type="image/webp"` for a couple source tags. Missing the AVIF source tag for product page.