### PR TITLE
Remove lazy load from product image affecting LCP

### DIFF
--- a/src/routes/products/[...slug]/index.tsx
+++ b/src/routes/products/[...slug]/index.tsx
@@ -105,8 +105,6 @@ export default component$(() => {
 													class="object-center object-cover rounded-lg"
 													width="400"
 													height="400"
-													loading="lazy"
-													decoding="async"
 												/>
 											</picture>
 										</div>


### PR DESCRIPTION
Remove lazy load from product image affecting LCP on Product page.

Example: https://pagespeed.web.dev/report?url=https%3A%2F%2Fqwik-storefront.vendure.io%2Fproducts%2Flaptop%2F

<img width="972" alt="Screen Shot 2022-12-06 at 1 40 46 AM" src="https://user-images.githubusercontent.com/3682072/205839729-c2366974-5298-427d-8c67-b6b0a4726925.png">
