### PR TITLE
Fix A11y Esc key dismissals, filter labels & text contrast

### DIFF
--- a/src/components/facet-filter-controls/Filters.tsx
+++ b/src/components/facet-filter-controls/Filters.tsx
@@ -44,13 +44,15 @@ export default component$<{
 								<div class="space-y-4">
 									{facet.values.map((value) => (
 										<div class="flex items-center">
-											<input
-												class="h-4 w-4 border-gray-300 rounded text-primary-600 focus:ring-primary-500"
-												type="checkbox"
-												checked={value.selected}
-												onClick$={() => onFilterChange$(value.id)}
-											/>
-											<label class="ml-3 text-sm text-gray-600">{value.name}</label>
+											<label class="text-sm text-gray-600">
+												<input
+													class="h-4 w-4 border-gray-300 rounded text-primary-600 focus:ring-primary-500"
+													type="checkbox"
+													checked={value.selected}
+													onClick$={() => onFilterChange$(value.id)}
+												/>
+												<span class="ml-3">{value.name}</span>
+											</label>
 										</div>
 									))}
 								</div>

--- a/src/components/filters-button/FiltersButton.tsx
+++ b/src/components/filters-button/FiltersButton.tsx
@@ -10,7 +10,7 @@ export default component$<{ onToggleMenu$: PropFunction<() => void> }>(({ onTogg
 				onToggleMenu$();
 			})}
 		>
-			<span>Filters</span>
+			<span class="text-gray-600 hover:text-gray-700">Filters</span>
 			<FilterIcon />
 		</button>
 	);

--- a/src/routes/collections/[...slug]/index.tsx
+++ b/src/routes/collections/[...slug]/index.tsx
@@ -1,6 +1,7 @@
 import {
 	$,
 	component$,
+	QwikKeyboardEvent,
 	Resource,
 	useClientEffect$,
 	useResource$,
@@ -80,7 +81,14 @@ export default component$(() => {
 	});
 
 	return (
-		<div class="max-w-6xl mx-auto px-4 py-10">
+		<div
+			class="max-w-6xl mx-auto px-4 py-10"
+			onKeyDown$={(event: QwikKeyboardEvent) => {
+				if (event.key === 'Escape') {
+					state.showMenu = false;
+				}
+			}}
+		>
 			<div class="flex justify-between items-center">
 				<Resource
 					value={collectionResource}
@@ -145,6 +153,9 @@ export default component$(() => {
 									state.showMenu = !state.showMenu;
 								}}
 								onFilterChange$={onFilterChange}
+								onEscapeMenu$={async () => {
+									state.showMenu = false;
+								}}
 							/>
 						)}
 						<div class="sm:col-span-5 lg:col-span-4">

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,8 +1,10 @@
 import {
+	$,
 	component$,
 	Slot,
 	useClientEffect$,
 	useContextProvider,
+	useOn,
 	useServerMount$,
 	useStore,
 } from '@builder.io/qwik';
@@ -33,6 +35,15 @@ export default component$(() => {
 		const { activeOrder } = await execute<{ activeOrder: ActiveOrder }>(getActiveOrderQuery());
 		state.activeOrder = activeOrder;
 	});
+
+	useOn(
+		'keydown',
+		$((event) => {
+			if ((event as KeyboardEvent).key === 'Escape') {
+				state.showCart = false;
+			}
+		})
+	);
 
 	return (
 		<div>

--- a/src/routes/search/index.tsx
+++ b/src/routes/search/index.tsx
@@ -1,4 +1,4 @@
-import { $, component$, useClientEffect$, useStore } from '@builder.io/qwik';
+import { $, component$, QwikKeyboardEvent, useClientEffect$, useStore } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 import Filters from '~/components/facet-filter-controls/Filters';
 import FiltersButton from '~/components/filters-button/FiltersButton';
@@ -54,7 +54,14 @@ export default component$(() => {
 	});
 
 	return (
-		<div class="max-w-6xl mx-auto px-4 py-10">
+		<div
+			class="max-w-6xl mx-auto px-4 py-10"
+			onKeyDown$={(event: QwikKeyboardEvent) => {
+				if (event.key === 'Escape') {
+					state.showMenu = false;
+				}
+			}}
+		>
 			<div class="flex justify-between items-center">
 				<h2 class="text-3xl sm:text-5xl font-light tracking-tight text-gray-900 my-8">
 					{term ? `Results for "${term}"` : 'All filtered results'}


### PR DESCRIPTION
Fixes several A11y bugs:

1. Adds Esc-key closing of shopping cart and filter dialogs
2. Fixes the Filter button contrast ratio on Search and Category list pages: 
<img width="971" alt="Screen Shot 2022-12-06 at 10 59 51 AM" src="https://user-images.githubusercontent.com/3682072/205961104-ec1d1bd9-abce-43eb-92db-dae84a245da1.png">

3. Refactors filter facets checkbox inputs inside their associated labels: 
<img width="971" alt="Screen Shot 2022-12-06 at 10 59 28 AM" src="https://user-images.githubusercontent.com/3682072/205961209-3eac89d6-3b29-4521-9343-f3fdebd28bd1.png">
