### PR TITLE
fix: search & subcollection

### DIFF
--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -21,12 +21,12 @@ export default component$<{ items: { name: string; slug: string; id: string }[] 
 						<li key={item.name}>
 							<div class="flex items-center">
 								<SlashIcon />
-								<Link
+								<a
 									href={'/collections/' + item.slug}
 									class="ml-2 md:ml-4 text-xs md:text-sm font-medium text-gray-500 hover:text-gray-700"
 								>
 									{item.name}
-								</Link>
+								</a>
 							</div>
 						</li>
 					))}

--- a/src/components/collection-card/CollectionCard.tsx
+++ b/src/components/collection-card/CollectionCard.tsx
@@ -1,5 +1,4 @@
 import { component$ } from '@builder.io/qwik';
-import { Link } from '@builder.io/qwik-city';
 import { Collection } from '../../types';
 
 interface IProps {
@@ -8,7 +7,7 @@ interface IProps {
 
 export default component$(({ collection }: IProps) => {
 	return (
-		<Link href={'/collections/' + collection.slug} key={collection.id}>
+		<a href={'/collections/' + collection.slug} key={collection.id}>
 			<div class="max-w-[300px] relative rounded-lg overflow-hidden hover:opacity-75 xl:w-auto mx-auto">
 				<span class="">
 					<div class="w-full h-full object-center object-cover">
@@ -35,6 +34,6 @@ export default component$(({ collection }: IProps) => {
 					{collection.name}
 				</span>
 			</div>
-		</Link>
+		</a>
 	);
 });

--- a/src/routes/search/index.tsx
+++ b/src/routes/search/index.tsx
@@ -1,4 +1,4 @@
-import { $, component$, QwikKeyboardEvent, useStore, useTask$ } from '@builder.io/qwik';
+import { $, component$, QwikKeyboardEvent, useClientEffect$, useStore } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 import { isBrowser } from '@builder.io/qwik/build';
 import Filters from '~/components/facet-filter-controls/Filters';
@@ -31,7 +31,7 @@ export default component$(() => {
 			await execute<{ search: Search }>(searchQueryWithTerm(term, activeFacetValueIds))
 	);
 
-	useTask$(async () => {
+	useClientEffect$(async () => {
 		if (isBrowser) {
 			window.scrollTo(0, 0);
 			const { search } = await executeQuery(term, activeFacetValueIds);


### PR DESCRIPTION
use must use <a> in some components because with <LInk> `useResource` is not triggered.
e.g. if you change the param without change the route
