### PR TITLE
Surfaces GraphQL API Errors to data providers

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -54,6 +54,10 @@ const executeRequest = async (options: Options) => {
 
 const extractTokenAndData = async (response: Response) => {
 	const token = response.headers.get(HEADER_AUTH_TOKEN_KEY) || '';
-	const { data } = await response.json();
+	const { data, errors } = await response.json();
+	if (errors && !data) {
+		// e.g. API access related errors, like auth issues.
+		throw new Error(errors[0].message);
+	}
 	return { token, data };
 };

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -25,7 +25,7 @@ const execute = async <R, V = Record<string, any>>(
 	if (authToken !== '') {
 		options.headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` };
 	}
-	const response: ResponseProps<R> = isBrowser
+	const response: ResponseProps<R> = isBrowser && !import.meta.env.DEV
 		? await executeOnTheServer(options)
 		: await executeRequest(options);
 


### PR DESCRIPTION
This is useful for components to know when an error occurs how to deal with it (e.g. redirect to login page for access related errors).

e.g.
const dataLoader = routeLoader$(async (requestEvent) => {
getOrderByCodeQuery(.....).then((data) => doSomething(data)).catch((err) => {
      if (err.message.indexOf('not currently authorized') >= 0) {
        throw requestEvent.redirect(
          302, `/login?callbackUrl=${requestEvent.url.href}`);
      }
    });
})