### PR TITLE
Update password change to not reload

### DIFF
--- a/src/routes/account/password/index.tsx
+++ b/src/routes/account/password/index.tsx
@@ -100,7 +100,7 @@ export default component$(() => {
 						<CheckIcon /> &nbsp; Save
 					</HighlightedButton>
 					<div>
-						<button onClick$={togglePasswordFields}>
+						<button preventdefault:click onClick$={togglePasswordFields}>
 							{showPasswordAsTextSignal.value ? <EyeIcon /> : <EyeSlashIcon />}
 						</button>
 					</div>


### PR DESCRIPTION
Since this button is part of a form I presume it is misfiring the submit form or something along those lines. preventdefault:click will stop that from happening. Perhaps there are other preventdefault events (like if tabbed to button and then "space" or "enter" is pressed - not sure).

Also I have a version which only reveals the bottom two "new" passwords, this might be more secure as an auto-fill might fill in the current password and revealing it, bypasses security (ie: browser requires password to see stored passwords). 

But that might be developer preference because perhaps user types current password and wants to know what they typed.