### PR TITLE
Make navbar stick to top

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -3,7 +3,6 @@ import { Link } from '@builder.io/qwik-city';
 import { APP_STATE, CUSTOMER_NOT_DEFINED_ID } from '~/constants';
 import { logoutMutation } from '~/providers/account/account';
 import { getActiveCustomerQuery } from '~/providers/customer/customer';
-import Cart from '../cart/Cart';
 import LogoutIcon from '../icons/LogoutIcon';
 import ShoppingBagIcon from '../icons/ShoppingBagIcon';
 import UserIcon from '../icons/UserIcon';
@@ -43,10 +42,10 @@ export default component$(() => {
 	});
 
 	return (
-		<div>
-			<header
-				class={`bg-gradient-to-r from-blue-700 to-indigo-900 transform shadow-xl sticky top-0 z-10 animate-dropIn`}
-			>
+		<div
+			class={`bg-gradient-to-r from-blue-700 to-indigo-900 transform shadow-xl sticky top-0 z-10 animate-dropIn`}
+		>
+			<header>
 				<div class="bg-zinc-100 text-gray-600 shadow-inner text-center text-sm py-1 px-2 xl:px-0">
 					<div class="max-w-6xl mx-2 h-5 min-h-full md:mx-auto flex items-center justify-between my-1">
 						<div class="flex justify-between items-center w-full">
@@ -125,7 +124,6 @@ export default component$(() => {
 					</div>
 				</div>
 			</header>
-			<Cart />
 		</div>
 	);
 });

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -16,6 +16,7 @@ import { getCollections } from '~/providers/collections/collections';
 import { getActiveOrderQuery } from '~/providers/orders/order';
 import { ActiveCustomer, AppState } from '~/types';
 import { extractLang } from '~/utils/i18n';
+import Cart from '../components/cart/Cart';
 import Footer from '../components/footer/footer';
 import Header from '../components/header/header';
 
@@ -88,6 +89,7 @@ export default component$(() => {
 	return (
 		<div>
 			<Header />
+			<Cart />
 			<main>
 				<Slot />
 			</main>


### PR DESCRIPTION
Angular storefront does this, but only on scroll up.

Curious if you know how to resize on scroll using qwik? ie: do I need it in a special $ function or something that will affect classes? See [issue](https://github.com/vendure-ecommerce/storefront-qwik-starter/issues/118#issuecomment-1642821121) for more info, Thanks! 