### PR TITLE
Removed undici from dependencies as not needed in prod and duplicated in devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,46 +6,46 @@
 		"": {
 			"name": "storefront-qwik-starter",
 			"dependencies": {
-				"@angular/localize": "^16.1.3",
-				"@builder.io/qwik-labs": "github:BuilderIo/qwik-labs-build#qwik-labs",
+				"@angular/localize": "^16.2.1",
 				"@graphql-codegen/typescript-generic-sdk": "^3.1.0",
-				"@stripe/stripe-js": "^1.54.1",
-				"braintree-web-drop-in": "^1.38.1",
-				"graphql": "^16.7.1",
+				"@stripe/stripe-js": "^2.1.0",
+				"braintree-web-drop-in": "^1.40.0",
+				"graphql": "^16.8.0",
 				"graphql-tag": "^2.12.6",
 				"qwik-image": "^0.0.7",
-				"undici": "^5.22.1",
-				"zod": "^3.21.4"
+				"zod": "^3.22.1"
 			},
 			"devDependencies": {
-				"@angular/compiler": "^16.1.3",
-				"@angular/compiler-cli": "^16.1.3",
-				"@builder.io/qwik": "1.2.4",
-				"@builder.io/qwik-city": "1.2.4",
-				"@graphql-codegen/cli": "^4.0.1",
+				"@angular/compiler": "^16.2.1",
+				"@angular/compiler-cli": "^16.2.1",
+				"@builder.io/qwik": "1.2.11",
+				"@builder.io/qwik-city": "1.2.11",
+				"@builder.io/qwik-labs": "github:BuilderIo/qwik-labs-build#adb8df9bc0d903229367113f31c9ca904b5187c5",
+				"@graphql-codegen/cli": "^5.0.0",
 				"@graphql-codegen/introspection": "^4.0.0",
 				"@graphql-codegen/typescript": "^4.0.1",
 				"@graphql-codegen/typescript-operations": "^4.0.1",
-				"@tailwindcss/forms": "^0.5.3",
-				"@types/braintree-web-drop-in": "^1.34.3",
-				"@types/eslint": "8.40.2",
-				"@types/node": "latest",
-				"@typescript-eslint/eslint-plugin": "5.61.0",
-				"@typescript-eslint/parser": "5.61.0",
-				"autoprefixer": "10.4.14",
+				"@tailwindcss/forms": "^0.5.4",
+				"@types/braintree-web-drop-in": "^1.39.0",
+				"@types/eslint": "8.44.2",
+				"@types/node": "20.5.0",
+				"@typescript-eslint/eslint-plugin": "6.4.0",
+				"@typescript-eslint/parser": "6.4.0",
+				"autoprefixer": "10.4.15",
 				"concurrently": "8.2.0",
-				"eslint": "8.44.0",
-				"eslint-plugin-qwik": "1.2.4",
+				"eslint": "8.45.0",
+				"eslint-plugin-qwik": "1.2.11",
 				"husky": "^8.0.3",
-				"node-fetch": "3.3.1",
-				"postcss": "8.4.24",
+				"node-fetch": "3.3.2",
+				"postcss": "8.4.28",
 				"prettier": "2.8.8",
 				"pretty-quick": "^3.1.3",
-				"tailwindcss": "3.3.2",
+				"tailwindcss": "3.3.3",
 				"typescript": "5.1.6",
-				"vite": "4.3.9",
+				"undici": "5.23.0",
+				"vite": "4.4.9",
 				"vite-tsconfig-paths": "4.2.0",
-				"wrangler": "latest"
+				"wrangler": "3.5.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -85,9 +85,9 @@
 			}
 		},
 		"node_modules/@angular/compiler": {
-			"version": "16.1.7",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.1.7.tgz",
-			"integrity": "sha512-93nbMFPSpKNfUyuRvEQxPdYLU6g25oZ4Gp7ewzNLyDHIbTQv6FwsthHfgPigPJJUUyKak6Gr3koFsgk7Dl3LAA==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.6.tgz",
+			"integrity": "sha512-FKv9isn8BdM9TydyhdqcFhFD8nn11+fGqg3qbIQnOlnLb0ryYign93zBmlx/qFu46PvPtTmhsa4saE2NwvrSbg==",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -95,7 +95,7 @@
 				"node": "^16.14.0 || >=18.10.0"
 			},
 			"peerDependencies": {
-				"@angular/core": "16.1.7"
+				"@angular/core": "16.2.6"
 			},
 			"peerDependenciesMeta": {
 				"@angular/core": {
@@ -104,9 +104,9 @@
 			}
 		},
 		"node_modules/@angular/compiler-cli": {
-			"version": "16.1.7",
-			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.1.7.tgz",
-			"integrity": "sha512-6iuogfVrbCh6o4hWbNCClsLQdLtlXiaNc72LGz5LMXI0TOwKVlRXhbzhiQeLS0/nsYIdHFbgyr1aepI2wQA3mQ==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.6.tgz",
+			"integrity": "sha512-rzyI4dKVj8T9dCnZCIffoxZ2PplYLmC9yd65VoaKxOQFxf/95/hgIRdt5kafjnZvzFN1qUbQuEfyviY+KFdQKg==",
 			"dependencies": {
 				"@babel/core": "7.22.5",
 				"@jridgewell/sourcemap-codec": "^1.4.14",
@@ -126,14 +126,14 @@
 				"node": "^16.14.0 || >=18.10.0"
 			},
 			"peerDependencies": {
-				"@angular/compiler": "16.1.7",
+				"@angular/compiler": "16.2.6",
 				"typescript": ">=4.9.3 <5.2"
 			}
 		},
 		"node_modules/@angular/localize": {
-			"version": "16.1.7",
-			"resolved": "https://registry.npmjs.org/@angular/localize/-/localize-16.1.7.tgz",
-			"integrity": "sha512-xxFwdu082rikBAQXshA8akc96lKFOusgOwa5kUh2m+d8h/Hp9sOl4nOtVuHqMLz/h1OJIpskoA22EasQaccaHg==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@angular/localize/-/localize-16.2.6.tgz",
+			"integrity": "sha512-sOkZcamHIpiklnbBXCplH7VhPV/aV1c0Cl62Q4lOa+pEnD1oPxE/oAQtFe+AHdf2rTnJhqCutvQDr5yGrIT+SQ==",
 			"dependencies": {
 				"@babel/core": "7.22.5",
 				"fast-glob": "3.3.0",
@@ -148,8 +148,8 @@
 				"node": "^16.14.0 || >=18.10.0"
 			},
 			"peerDependencies": {
-				"@angular/compiler": "16.1.7",
-				"@angular/compiler-cli": "16.1.7"
+				"@angular/compiler": "16.2.6",
+				"@angular/compiler-cli": "16.2.6"
 			}
 		},
 		"node_modules/@ardatan/relay-compiler": {
@@ -1208,9 +1208,9 @@
 			"integrity": "sha512-tVpr7U6u6bqeQlHreEjYMNtnHX62vLnNWziY2kQLqkWhvusPuY5DfuGEIPpWqsd+V/a1slyTQaxK6HWTlH6A/Q=="
 		},
 		"node_modules/@braintree/sanitize-url": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
-			"integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
 		},
 		"node_modules/@braintree/uuid": {
 			"version": "0.1.0",
@@ -1223,9 +1223,9 @@
 			"integrity": "sha512-UIrJB+AfKU0CCfbMoWrsGpd2D/hBpY/SGgFI6WRHPOwhaZ3g9rz1weiJ6eb6L9KgVyunT7s2tckcPkbHw+NzeA=="
 		},
 		"node_modules/@builder.io/qwik": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-1.2.4.tgz",
-			"integrity": "sha512-8nCSI23v3pxR8sMvoM/fw0wBSaxpITRwEyt7XTHRt+xoRwdQnfap8td66j+D7EDFDBynO88afKkmLZhMzDmW5A==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-1.2.11.tgz",
+			"integrity": "sha512-C0umHmXhKdMu2dP/UTBEvuoSC1pfYSPC43jzYiF6dMXpQasgyDXIQML8yzrAsxnimr7OfKfn2vNyn2t5e9BG8A==",
 			"dev": true,
 			"dependencies": {
 				"csstype": "^3.1.2"
@@ -1241,28 +1241,78 @@
 			}
 		},
 		"node_modules/@builder.io/qwik-city": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-1.2.4.tgz",
-			"integrity": "sha512-WAYf7ZsYpyR7NrLW8VjyQ2GehD4HruD1T3DtQ0ga8S+2IDUXiQY3zW81y2wr3h+FQhfwctGB9xK3cj04ZM+WlA==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-1.2.11.tgz",
+			"integrity": "sha512-meeApo5czwGsn7bywtu2P4bBdRTprwtfjcwE06APvhRF2Y5xK0bv7vW9vGbRvPy/w6o5Izc+CauLepryOcXiGg==",
 			"dev": true,
 			"dependencies": {
 				"@mdx-js/mdx": "2.3.0",
 				"@types/mdx": "2.0.5",
 				"source-map": "0.7.4",
 				"svgo": "^3.0.2",
-				"vfile": "5.3.7",
-				"vite-imagetools": "^5.0.4",
+				"vfile": "^6.0.1",
+				"vite-imagetools": "^5.0.5",
 				"zod": "^3.21.4"
 			},
 			"engines": {
 				"node": ">=16.8.0 <18.0.0 || >=18.11"
 			}
 		},
+		"node_modules/@builder.io/qwik-city/node_modules/@types/unist": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+			"integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+			"dev": true
+		},
+		"node_modules/@builder.io/qwik-city/node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@builder.io/qwik-city/node_modules/vfile": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+			"integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@builder.io/qwik-city/node_modules/vfile-message": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+			"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/@builder.io/qwik-labs": {
 			"version": "0.0.1",
-			"resolved": "git+ssh://git@github.com/BuilderIo/qwik-labs-build.git#11ce541e61b098ee97e0c3c46d77946c968e5428",
+			"resolved": "git+ssh://git@github.com/BuilderIo/qwik-labs-build.git#adb8df9bc0d903229367113f31c9ca904b5187c5",
+			"integrity": "sha512-BBjC8eIW+HRmsNXbKCQhzeU+/FzQXfgmjK/H/qMU710ZW9avEr5G84VJ4s6uxUVyQaZJptgIXr+jDzT4UARJTQ==",
+			"dev": true,
 			"engines": {
-				"node": ">=16"
+				"node": ">=16.8.0 <18.0.0 || >=18.11"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -1275,9 +1325,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230724.0.tgz",
-			"integrity": "sha512-DQmFZWHhs8waQFYRb/Z8QmbitAvBMXnbUMUentp+3lS4eCYI0/iurTaQDiz5+ldUn9FTxD+1XuYZlTHzVNxoHw==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
+			"integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
 			"cpu": [
 				"x64"
 			],
@@ -1291,9 +1341,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230724.0.tgz",
-			"integrity": "sha512-C7T0v/lMjEX7c4iROSZKgIF1eGw3+sj/gFpBD6xwxfbIcrKBjncMypeLQNpRTCdBQr1W3sNpg9jagwuVX5ByZQ==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1307,9 +1357,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230724.0.tgz",
-			"integrity": "sha512-o0F/hj73UXOQwkPkYqZuIxpjG8gAs2eoAGqxX1HSIYRf7iUhfFcPrupwjqlNqf7Oo1h46M+sClSFjr/ZU/LCjg==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
+			"integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
 			"cpu": [
 				"x64"
 			],
@@ -1323,9 +1373,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230724.0.tgz",
-			"integrity": "sha512-UpzCoo7LOuPWxFPw84TZQTPIawIDQNSb3XnC6ffMjUH/FVwHmHdngIFZxW+xjLHKMIzGNAqSn3eRHekKgO3QqA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1339,9 +1389,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230724.0.tgz",
-			"integrity": "sha512-wVpPNu19fnvgsD8V6NiGPSuET0bzKmgn3wJ6RwAwQA+GQ0hdDIDVYd13aImhgO6jLfQvkduCDxeZluGZ7PPojQ==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
+			"integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
 			"cpu": [
 				"x64"
 			],
@@ -1389,9 +1439,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+			"integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
 			"cpu": [
 				"arm"
 			],
@@ -1405,9 +1455,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+			"integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1421,9 +1471,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+			"integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
 			"cpu": [
 				"x64"
 			],
@@ -1437,9 +1487,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+			"integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1453,9 +1503,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+			"integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1469,9 +1519,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+			"integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1485,9 +1535,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+			"integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1501,9 +1551,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+			"integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
 			"cpu": [
 				"arm"
 			],
@@ -1517,9 +1567,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+			"integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1533,9 +1583,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+			"integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1549,9 +1599,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+			"integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
 			"cpu": [
 				"loong64"
 			],
@@ -1565,9 +1615,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+			"integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1581,9 +1631,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+			"integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1597,9 +1647,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+			"integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1613,9 +1663,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+			"integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1629,9 +1679,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+			"integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
 			"cpu": [
 				"x64"
 			],
@@ -1645,9 +1695,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
 			"cpu": [
 				"x64"
 			],
@@ -1661,9 +1711,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
 			"cpu": [
 				"x64"
 			],
@@ -1677,9 +1727,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+			"integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1693,9 +1743,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+			"integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1709,9 +1759,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+			"integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
 			"cpu": [
 				"ia32"
 			],
@@ -1725,9 +1775,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+			"integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1824,16 +1874,16 @@
 			}
 		},
 		"node_modules/@graphql-codegen/cli": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-4.0.1.tgz",
-			"integrity": "sha512-/H4imnGOl3hoPXLKmIiGUnXpmBmeIClSZie/YHDzD5N59cZlGGJlIOOrUlOTDpJx5JNU1MTQcRjyTToOYM5IfA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.0.tgz",
+			"integrity": "sha512-A7J7+be/a6e+/ul2KI5sfJlpoqeqwX8EzktaKCeduyVKgOLA6W5t+NUGf6QumBDXU8PEOqXk3o3F+RAwCWOiqA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/generator": "^7.18.13",
 				"@babel/template": "^7.18.10",
 				"@babel/types": "^7.18.13",
 				"@graphql-codegen/core": "^4.0.0",
-				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/plugin-helpers": "^5.0.1",
 				"@graphql-tools/apollo-engine-loader": "^8.0.0",
 				"@graphql-tools/code-file-loader": "^8.0.0",
 				"@graphql-tools/git-loader": "^8.0.0",
@@ -1844,7 +1894,6 @@
 				"@graphql-tools/prisma-loader": "^8.0.0",
 				"@graphql-tools/url-loader": "^8.0.0",
 				"@graphql-tools/utils": "^10.0.0",
-				"@parcel/watcher": "^2.1.0",
 				"@whatwg-node/fetch": "^0.8.0",
 				"chalk": "^4.1.0",
 				"cosmiconfig": "^8.1.3",
@@ -1862,7 +1911,7 @@
 				"string-env-interpolation": "^1.0.1",
 				"ts-log": "^2.2.3",
 				"tslib": "^2.4.0",
-				"yaml": "^1.10.0",
+				"yaml": "^2.3.1",
 				"yargs": "^17.0.0"
 			},
 			"bin": {
@@ -1872,7 +1921,13 @@
 				"graphql-codegen-esm": "esm/bin.js"
 			},
 			"peerDependencies": {
+				"@parcel/watcher": "^2.1.0",
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@parcel/watcher": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@graphql-codegen/cli/node_modules/ansi-styles": {
@@ -3171,6 +3226,8 @@
 			"integrity": "sha512-71S4TF+IMyAn24PK4KSkdKtqJDR3zRzb0HE3yXpacItqTM7XfF2f5q9NEGLEVl0dAaBAGfNwDCjH120y25F6Tg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^1.0.3",
 				"is-glob": "^4.0.3",
@@ -3209,6 +3266,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3229,6 +3287,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3249,6 +3308,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3269,6 +3329,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3289,6 +3350,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3309,6 +3371,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3329,6 +3392,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3349,6 +3413,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3369,6 +3434,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3389,6 +3455,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -3471,9 +3538,9 @@
 			"dev": true
 		},
 		"node_modules/@stripe/stripe-js": {
-			"version": "1.54.1",
-			"resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.54.1.tgz",
-			"integrity": "sha512-smEXPu1GKMcAj9g2luT16+oXfg2jAwyc68t2Dm5wdtYl3p8PqQaZEiI8tQmboaQAjgF8pIGma6byz1T1vgmpbA=="
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-2.1.6.tgz",
+			"integrity": "sha512-QSzqQIcowgap7a40f3a7oUR+59Xet/i8fp1EsnzzwxK5oPRQsCbbLQ4Cd6qM0y1pdZMonFnCrAWayWdE9Lr0iA=="
 		},
 		"node_modules/@tailwindcss/forms": {
 			"version": "0.5.4",
@@ -3522,9 +3589,9 @@
 			}
 		},
 		"node_modules/@types/braintree-web-drop-in": {
-			"version": "1.34.3",
-			"resolved": "https://registry.npmjs.org/@types/braintree-web-drop-in/-/braintree-web-drop-in-1.34.3.tgz",
-			"integrity": "sha512-as0s8S1KFLMuMd7rJfogm3dky/7QMfh9Mw6k9XmnMYpJIck+6mVW/WGGkd8MAgYfDzFtAHLT/vjazRzmI9sNSg==",
+			"version": "1.39.1",
+			"resolved": "https://registry.npmjs.org/@types/braintree-web-drop-in/-/braintree-web-drop-in-1.39.1.tgz",
+			"integrity": "sha512-gvFOvQhtRb3nmsKzPBd32oEdqQq6DeCdlm4xLRqe8QpGblIKaEi4MIaU/pCNTxaVyYlIFMiUAO2H2xFyvejtgQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/applepayjs": "*",
@@ -3543,9 +3610,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.40.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
-			"integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
+			"version": "8.44.2",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
+			"integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -3628,9 +3695,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.4.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-			"integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+			"integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==",
 			"dev": true
 		},
 		"node_modules/@types/paypal-checkout-components": {
@@ -3640,9 +3707,9 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
 			"dev": true
 		},
 		"node_modules/@types/unist": {
@@ -3661,32 +3728,33 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz",
-			"integrity": "sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
+			"integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.61.0",
-				"@typescript-eslint/type-utils": "5.61.0",
-				"@typescript-eslint/utils": "5.61.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.4.0",
+				"@typescript-eslint/type-utils": "6.4.0",
+				"@typescript-eslint/utils": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -3695,25 +3763,26 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.61.0.tgz",
-			"integrity": "sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+			"integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.61.0",
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/typescript-estree": "5.61.0",
+				"@typescript-eslint/scope-manager": "6.4.0",
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/typescript-estree": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -3722,16 +3791,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
-			"integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+			"integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/visitor-keys": "5.61.0"
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3739,25 +3808,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.61.0.tgz",
-			"integrity": "sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
+			"integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.61.0",
-				"@typescript-eslint/utils": "5.61.0",
+				"@typescript-eslint/typescript-estree": "6.4.0",
+				"@typescript-eslint/utils": "6.4.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -3766,12 +3835,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
-			"integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+			"integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
 			"dev": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3779,21 +3848,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
-			"integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+			"integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/visitor-keys": "5.61.0",
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3806,42 +3875,41 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.61.0.tgz",
-			"integrity": "sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
+			"integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.61.0",
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/typescript-estree": "5.61.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.4.0",
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/typescript-estree": "6.4.0",
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
-			"integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+			"integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.61.0",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "6.4.0",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4170,9 +4238,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.14",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-			"integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+			"version": "10.4.15",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+			"integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
 			"dev": true,
 			"funding": [
 				{
@@ -4182,11 +4250,15 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"browserslist": "^4.21.5",
-				"caniuse-lite": "^1.0.30001464",
+				"browserslist": "^4.21.10",
+				"caniuse-lite": "^1.0.30001520",
 				"fraction.js": "^4.2.0",
 				"normalize-range": "^0.1.2",
 				"picocolors": "^1.0.0",
@@ -4298,14 +4370,14 @@
 			]
 		},
 		"node_modules/better-sqlite3": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.5.0.tgz",
-			"integrity": "sha512-vbPcv/Hx5WYdyNg/NbcfyaBZyv9s/NVbxb7yCeC5Bq1pVocNxeL2tZmSu3Rlm4IEOTjYdGyzWQgyx0OSdORBzw==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.6.0.tgz",
+			"integrity": "sha512-jwAudeiTMTSyby+/SfbHDebShbmC2MCH8mU2+DXi0WJfv13ypEJm47cd3kljmy/H130CazEvkf2Li//ewcMJ1g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"bindings": "^1.5.0",
-				"prebuild-install": "^7.1.0"
+				"prebuild-install": "^7.1.1"
 			}
 		},
 		"node_modules/binary-extensions": {
@@ -4369,16 +4441,16 @@
 			}
 		},
 		"node_modules/braintree-web": {
-			"version": "3.96.1",
-			"resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.96.1.tgz",
-			"integrity": "sha512-e483TQkRmcO5zFH+pMGUokFWq5Q+Jyn9TmUIDofPpul1P+xOciwNqvekl/Ku6MsJBT1+kyH0cndBYMZVJpbrtg==",
+			"version": "3.97.1",
+			"resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.97.1.tgz",
+			"integrity": "sha512-9f9yNoC+vS9RGrkAaE80BbyX4L1JE9j+ZzgT66MxiU6011J6Bs3E+iLtXodi2bpFTRlBlT0F4GIW5kHT7RC6bQ==",
 			"dependencies": {
 				"@braintree/asset-loader": "0.4.4",
-				"@braintree/browser-detection": "1.14.0",
+				"@braintree/browser-detection": "1.17.1",
 				"@braintree/event-emitter": "0.4.1",
 				"@braintree/extended-promise": "0.4.1",
 				"@braintree/iframer": "1.1.0",
-				"@braintree/sanitize-url": "6.0.2",
+				"@braintree/sanitize-url": "6.0.4",
 				"@braintree/uuid": "0.1.0",
 				"@braintree/wrap-promise": "2.1.0",
 				"card-validator": "8.1.1",
@@ -4390,17 +4462,22 @@
 			}
 		},
 		"node_modules/braintree-web-drop-in": {
-			"version": "1.39.1",
-			"resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.39.1.tgz",
-			"integrity": "sha512-qpSXoSnT0fhQMmBctv/xntw5MoJgShW9A2p2L29oTteMtwKsPMY5um/VpevbFWibKuNdV1PW+nagzYJDKp61LA==",
+			"version": "1.40.2",
+			"resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.40.2.tgz",
+			"integrity": "sha512-m7sfLevcq/Q16ZGIFPNBbLNrnWEgtUZN939nyrpTd9My7O5v8A+BfqOQePEmBy+wkiWMC33i1Csk5peq69FWVw==",
 			"dependencies": {
 				"@braintree/asset-loader": "0.4.4",
 				"@braintree/browser-detection": "1.14.0",
 				"@braintree/event-emitter": "0.4.1",
 				"@braintree/uuid": "0.1.0",
 				"@braintree/wrap-promise": "2.1.0",
-				"braintree-web": "3.96.1"
+				"braintree-web": "3.97.1"
 			}
+		},
+		"node_modules/braintree-web/node_modules/@braintree/browser-detection": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.17.1.tgz",
+			"integrity": "sha512-Mk7jauyp9pD14BTRS7otoy9dqIJGb3Oy0XtxKM/adGD9i9MAuCjH5uRZMyW2iVmJQTaA/PLlWdG7eSDyMWMc8Q=="
 		},
 		"node_modules/braintree-web/node_modules/promise-polyfill": {
 			"version": "8.2.3",
@@ -4408,9 +4485,9 @@
 			"integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg=="
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.9",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-			"integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+			"version": "4.21.11",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.11.tgz",
+			"integrity": "sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4426,10 +4503,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001503",
-				"electron-to-chromium": "^1.4.431",
-				"node-releases": "^2.0.12",
-				"update-browserslist-db": "^1.0.11"
+				"caniuse-lite": "^1.0.30001538",
+				"electron-to-chromium": "^1.4.526",
+				"node-releases": "^2.0.13",
+				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -4480,6 +4557,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
 			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dev": true,
 			"dependencies": {
 				"streamsearch": "^1.1.0"
 			},
@@ -4536,9 +4614,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001517",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-			"integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+			"version": "1.0.30001539",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz",
+			"integrity": "sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5346,6 +5424,8 @@
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"detect-libc": "bin/detect-libc.js"
 			},
@@ -5484,9 +5564,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.477",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz",
-			"integrity": "sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw=="
+			"version": "1.4.529",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.529.tgz",
+			"integrity": "sha512-6uyPyXTo8lkv8SWAmjKFbG42U073TXlzD4R8rW3EzuznhFS2olCIAfjjQtV2dV2ar/vRF55KUd3zQYnCB0dd3A=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -5617,9 +5697,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+			"integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -5629,28 +5709,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.19",
-				"@esbuild/android-arm64": "0.17.19",
-				"@esbuild/android-x64": "0.17.19",
-				"@esbuild/darwin-arm64": "0.17.19",
-				"@esbuild/darwin-x64": "0.17.19",
-				"@esbuild/freebsd-arm64": "0.17.19",
-				"@esbuild/freebsd-x64": "0.17.19",
-				"@esbuild/linux-arm": "0.17.19",
-				"@esbuild/linux-arm64": "0.17.19",
-				"@esbuild/linux-ia32": "0.17.19",
-				"@esbuild/linux-loong64": "0.17.19",
-				"@esbuild/linux-mips64el": "0.17.19",
-				"@esbuild/linux-ppc64": "0.17.19",
-				"@esbuild/linux-riscv64": "0.17.19",
-				"@esbuild/linux-s390x": "0.17.19",
-				"@esbuild/linux-x64": "0.17.19",
-				"@esbuild/netbsd-x64": "0.17.19",
-				"@esbuild/openbsd-x64": "0.17.19",
-				"@esbuild/sunos-x64": "0.17.19",
-				"@esbuild/win32-arm64": "0.17.19",
-				"@esbuild/win32-ia32": "0.17.19",
-				"@esbuild/win32-x64": "0.17.19"
+				"@esbuild/android-arm": "0.18.20",
+				"@esbuild/android-arm64": "0.18.20",
+				"@esbuild/android-x64": "0.18.20",
+				"@esbuild/darwin-arm64": "0.18.20",
+				"@esbuild/darwin-x64": "0.18.20",
+				"@esbuild/freebsd-arm64": "0.18.20",
+				"@esbuild/freebsd-x64": "0.18.20",
+				"@esbuild/linux-arm": "0.18.20",
+				"@esbuild/linux-arm64": "0.18.20",
+				"@esbuild/linux-ia32": "0.18.20",
+				"@esbuild/linux-loong64": "0.18.20",
+				"@esbuild/linux-mips64el": "0.18.20",
+				"@esbuild/linux-ppc64": "0.18.20",
+				"@esbuild/linux-riscv64": "0.18.20",
+				"@esbuild/linux-s390x": "0.18.20",
+				"@esbuild/linux-x64": "0.18.20",
+				"@esbuild/netbsd-x64": "0.18.20",
+				"@esbuild/openbsd-x64": "0.18.20",
+				"@esbuild/sunos-x64": "0.18.20",
+				"@esbuild/win32-arm64": "0.18.20",
+				"@esbuild/win32-ia32": "0.18.20",
+				"@esbuild/win32-x64": "0.18.20"
 			}
 		},
 		"node_modules/escalade": {
@@ -5670,9 +5750,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.44.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-			"integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+			"version": "8.45.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+			"integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
@@ -5700,7 +5780,6 @@
 				"globals": "^13.19.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
@@ -5712,7 +5791,6 @@
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"bin": {
@@ -5726,31 +5804,18 @@
 			}
 		},
 		"node_modules/eslint-plugin-qwik": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qwik/-/eslint-plugin-qwik-1.2.4.tgz",
-			"integrity": "sha512-4bckfkFLYaJ0ngVBsUQPukr/lazShZ/dSKf3zm+UzBPJSpPdFOElXdPJAwAgEGvFobpMWsWFEhas1LN144YFAw==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qwik/-/eslint-plugin-qwik-1.2.11.tgz",
+			"integrity": "sha512-F4h4waCC9g8cXREVgHLhUzlbPkKJ7TpuUd1xmFQ0D+vYXvKk7RYYC1azBZMXqcc09b8XXz1UuvR2HLMrf/JblQ==",
 			"dev": true,
 			"dependencies": {
 				"jsx-ast-utils": "^3.3.4"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=16.8.0 <18.0.0 || >=18.11"
 			},
 			"peerDependencies": {
-				"eslint": ">= 8"
-			}
-		},
-		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
+				"eslint": "^8.45.0"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
@@ -5965,15 +6030,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
@@ -6636,9 +6692,9 @@
 			"dev": true
 		},
 		"node_modules/graphql": {
-			"version": "16.7.1",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-			"integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+			"version": "16.8.1",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+			"integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -8947,9 +9003,9 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "3.20230724.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230724.0.tgz",
-			"integrity": "sha512-YU8yUwoVJCiuzY2i9ZBJ+McjL/mqwKnMJfn23QedSCvx82Mys8GAlkHCH69mqSqzlSw8IVcdxec330meRRf9bg==",
+			"version": "3.20230814.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230814.1.tgz",
+			"integrity": "sha512-LMgqd1Ut0+fnlvQepVbbBYQczQnyuuap8bgUwOyPETka0S9NR9NxMQSNaBgVZ0uOaG7xMJ/OVTRlz+TGB86PWA==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -8964,7 +9020,7 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "1.20230724.0",
+				"workerd": "1.20230814.1",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
@@ -9085,12 +9141,6 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -9116,7 +9166,9 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
 			"integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/node-domexception": {
 			"version": "1.0.0",
@@ -9138,9 +9190,9 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"dev": true,
 			"dependencies": {
 				"data-uri-to-buffer": "^4.0.0",
@@ -9686,9 +9738,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.24",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-			"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+			"version": "8.4.28",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+			"integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
 			"dev": true,
 			"funding": [
 				{
@@ -9776,15 +9828,6 @@
 				"ts-node": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/postcss-load-config/node_modules/yaml": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-			"integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/postcss-nested": {
@@ -10399,9 +10442,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.0.tgz",
-			"integrity": "sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==",
+			"version": "3.29.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.3.tgz",
+			"integrity": "sha512-T7du6Hum8jOkSWetjRgbwpM6Sy0nECYrYRSmZjayFcOddtKJWU4d17AC3HNUk7HRuqy4p+G7aEZclSHytqUmEg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -10950,6 +10993,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
 			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -11199,9 +11243,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
-			"integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
+			"integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
 			"dev": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
@@ -11224,7 +11268,6 @@
 				"postcss-load-config": "^4.0.1",
 				"postcss-nested": "^6.0.1",
 				"postcss-selector-parser": "^6.0.11",
-				"postcss-value-parser": "^4.2.0",
 				"resolve": "^1.22.2",
 				"sucrase": "^3.32.0"
 			},
@@ -11376,6 +11419,18 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.13.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -11412,27 +11467,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
 			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/tsutils/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
@@ -11589,9 +11623,10 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.22.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-			"integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+			"version": "5.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+			"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
@@ -11748,9 +11783,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -11880,14 +11915,14 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.3.9",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
-			"integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+			"integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.17.5",
-				"postcss": "^8.4.23",
-				"rollup": "^3.21.0"
+				"esbuild": "^0.18.10",
+				"postcss": "^8.4.27",
+				"rollup": "^3.27.1"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -11895,12 +11930,16 @@
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
 			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
 				"@types/node": ">= 14",
 				"less": "*",
+				"lightningcss": "^1.21.0",
 				"sass": "*",
 				"stylus": "*",
 				"sugarss": "*",
@@ -11911,6 +11950,9 @@
 					"optional": true
 				},
 				"less": {
+					"optional": true
+				},
+				"lightningcss": {
 					"optional": true
 				},
 				"sass": {
@@ -12060,9 +12102,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230724.0.tgz",
-			"integrity": "sha512-++D7JqS4/dk7zvtGpk+i/7G9bZtEl6lTtgAsIoSSGR1qJAxxEu21ktm9+FH0EYh7uKfizuM5H9lrTsR+3u44PA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
+			"integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -12072,17 +12114,17 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20230724.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230724.0",
-				"@cloudflare/workerd-linux-64": "1.20230724.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230724.0",
-				"@cloudflare/workerd-windows-64": "1.20230724.0"
+				"@cloudflare/workerd-darwin-64": "1.20230814.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20230814.1",
+				"@cloudflare/workerd-linux-64": "1.20230814.1",
+				"@cloudflare/workerd-linux-arm64": "1.20230814.1",
+				"@cloudflare/workerd-windows-64": "1.20230814.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.4.0.tgz",
-			"integrity": "sha512-sATQ84zH/zFUHSaa4hY3V24TBrad3R9HhGV47U6Ek7XRQDLQHBm0jt84mJD3sSV/hhaq5s+xidIYulhm+m1/Tg==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.5.1.tgz",
+			"integrity": "sha512-CnrKId+pmjTfLSidM9Ut7lUDCFWEtJyY3JT3Dk+TgYHvu2zVmMgUeQQZHZfvpVN5eaEZifNQr90KEvMLy7MhHw==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "^0.2.0",
@@ -12091,7 +12133,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.16.3",
-				"miniflare": "3.20230724.0",
+				"miniflare": "3.20230814.1",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -12590,12 +12632,12 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+			"integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
 			"dev": true,
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/yaml-ast-parser": {
@@ -12642,9 +12684,9 @@
 			}
 		},
 		"node_modules/youch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.2.tgz",
+			"integrity": "sha512-9cwz/z7abtcHOIuH45nzmUFCZbyJA1nLqlirKvyNRx4wDMhqsBaifAJzBej7L4fsVPjFxYq3NK3GAcfvZsydFw==",
 			"dev": true,
 			"dependencies": {
 				"cookie": "^0.5.0",
@@ -12653,9 +12695,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.21.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-			"integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+			"version": "3.22.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+			"integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -12694,17 +12736,17 @@
 			}
 		},
 		"@angular/compiler": {
-			"version": "16.1.7",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.1.7.tgz",
-			"integrity": "sha512-93nbMFPSpKNfUyuRvEQxPdYLU6g25oZ4Gp7ewzNLyDHIbTQv6FwsthHfgPigPJJUUyKak6Gr3koFsgk7Dl3LAA==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.6.tgz",
+			"integrity": "sha512-FKv9isn8BdM9TydyhdqcFhFD8nn11+fGqg3qbIQnOlnLb0ryYign93zBmlx/qFu46PvPtTmhsa4saE2NwvrSbg==",
 			"requires": {
 				"tslib": "^2.3.0"
 			}
 		},
 		"@angular/compiler-cli": {
-			"version": "16.1.7",
-			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.1.7.tgz",
-			"integrity": "sha512-6iuogfVrbCh6o4hWbNCClsLQdLtlXiaNc72LGz5LMXI0TOwKVlRXhbzhiQeLS0/nsYIdHFbgyr1aepI2wQA3mQ==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.6.tgz",
+			"integrity": "sha512-rzyI4dKVj8T9dCnZCIffoxZ2PplYLmC9yd65VoaKxOQFxf/95/hgIRdt5kafjnZvzFN1qUbQuEfyviY+KFdQKg==",
 			"requires": {
 				"@babel/core": "7.22.5",
 				"@jridgewell/sourcemap-codec": "^1.4.14",
@@ -12717,9 +12759,9 @@
 			}
 		},
 		"@angular/localize": {
-			"version": "16.1.7",
-			"resolved": "https://registry.npmjs.org/@angular/localize/-/localize-16.1.7.tgz",
-			"integrity": "sha512-xxFwdu082rikBAQXshA8akc96lKFOusgOwa5kUh2m+d8h/Hp9sOl4nOtVuHqMLz/h1OJIpskoA22EasQaccaHg==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@angular/localize/-/localize-16.2.6.tgz",
+			"integrity": "sha512-sOkZcamHIpiklnbBXCplH7VhPV/aV1c0Cl62Q4lOa+pEnD1oPxE/oAQtFe+AHdf2rTnJhqCutvQDr5yGrIT+SQ==",
 			"requires": {
 				"@babel/core": "7.22.5",
 				"fast-glob": "3.3.0",
@@ -13456,9 +13498,9 @@
 			"integrity": "sha512-tVpr7U6u6bqeQlHreEjYMNtnHX62vLnNWziY2kQLqkWhvusPuY5DfuGEIPpWqsd+V/a1slyTQaxK6HWTlH6A/Q=="
 		},
 		"@braintree/sanitize-url": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
-			"integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
 		},
 		"@braintree/uuid": {
 			"version": "0.1.0",
@@ -13471,32 +13513,72 @@
 			"integrity": "sha512-UIrJB+AfKU0CCfbMoWrsGpd2D/hBpY/SGgFI6WRHPOwhaZ3g9rz1weiJ6eb6L9KgVyunT7s2tckcPkbHw+NzeA=="
 		},
 		"@builder.io/qwik": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-1.2.4.tgz",
-			"integrity": "sha512-8nCSI23v3pxR8sMvoM/fw0wBSaxpITRwEyt7XTHRt+xoRwdQnfap8td66j+D7EDFDBynO88afKkmLZhMzDmW5A==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-1.2.11.tgz",
+			"integrity": "sha512-C0umHmXhKdMu2dP/UTBEvuoSC1pfYSPC43jzYiF6dMXpQasgyDXIQML8yzrAsxnimr7OfKfn2vNyn2t5e9BG8A==",
 			"dev": true,
 			"requires": {
 				"csstype": "^3.1.2"
 			}
 		},
 		"@builder.io/qwik-city": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-1.2.4.tgz",
-			"integrity": "sha512-WAYf7ZsYpyR7NrLW8VjyQ2GehD4HruD1T3DtQ0ga8S+2IDUXiQY3zW81y2wr3h+FQhfwctGB9xK3cj04ZM+WlA==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-1.2.11.tgz",
+			"integrity": "sha512-meeApo5czwGsn7bywtu2P4bBdRTprwtfjcwE06APvhRF2Y5xK0bv7vW9vGbRvPy/w6o5Izc+CauLepryOcXiGg==",
 			"dev": true,
 			"requires": {
 				"@mdx-js/mdx": "2.3.0",
 				"@types/mdx": "2.0.5",
 				"source-map": "0.7.4",
 				"svgo": "^3.0.2",
-				"vfile": "5.3.7",
-				"vite-imagetools": "^5.0.4",
+				"vfile": "^6.0.1",
+				"vite-imagetools": "^5.0.5",
 				"zod": "^3.21.4"
+			},
+			"dependencies": {
+				"@types/unist": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+					"integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+					"dev": true
+				},
+				"unist-util-stringify-position": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+					"dev": true,
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"vfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+					"integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+					"dev": true,
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-stringify-position": "^4.0.0",
+						"vfile-message": "^4.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+					"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+					"dev": true,
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-stringify-position": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@builder.io/qwik-labs": {
-			"version": "git+ssh://git@github.com/BuilderIo/qwik-labs-build.git#11ce541e61b098ee97e0c3c46d77946c968e5428",
-			"from": "@builder.io/qwik-labs@github:BuilderIo/qwik-labs-build#qwik-labs"
+			"version": "git+ssh://git@github.com/BuilderIo/qwik-labs-build.git#adb8df9bc0d903229367113f31c9ca904b5187c5",
+			"integrity": "sha512-BBjC8eIW+HRmsNXbKCQhzeU+/FzQXfgmjK/H/qMU710ZW9avEr5G84VJ4s6uxUVyQaZJptgIXr+jDzT4UARJTQ==",
+			"dev": true,
+			"from": "@builder.io/qwik-labs@github:BuilderIo/qwik-labs-build#adb8df9bc0d903229367113f31c9ca904b5187c5"
 		},
 		"@cloudflare/kv-asset-handler": {
 			"version": "0.2.0",
@@ -13508,37 +13590,37 @@
 			}
 		},
 		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230724.0.tgz",
-			"integrity": "sha512-DQmFZWHhs8waQFYRb/Z8QmbitAvBMXnbUMUentp+3lS4eCYI0/iurTaQDiz5+ldUn9FTxD+1XuYZlTHzVNxoHw==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
+			"integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230724.0.tgz",
-			"integrity": "sha512-C7T0v/lMjEX7c4iROSZKgIF1eGw3+sj/gFpBD6xwxfbIcrKBjncMypeLQNpRTCdBQr1W3sNpg9jagwuVX5ByZQ==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230724.0.tgz",
-			"integrity": "sha512-o0F/hj73UXOQwkPkYqZuIxpjG8gAs2eoAGqxX1HSIYRf7iUhfFcPrupwjqlNqf7Oo1h46M+sClSFjr/ZU/LCjg==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
+			"integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230724.0.tgz",
-			"integrity": "sha512-UpzCoo7LOuPWxFPw84TZQTPIawIDQNSb3XnC6ffMjUH/FVwHmHdngIFZxW+xjLHKMIzGNAqSn3eRHekKgO3QqA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-windows-64": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230724.0.tgz",
-			"integrity": "sha512-wVpPNu19fnvgsD8V6NiGPSuET0bzKmgn3wJ6RwAwQA+GQ0hdDIDVYd13aImhgO6jLfQvkduCDxeZluGZ7PPojQ==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
+			"integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
 			"dev": true,
 			"optional": true
 		},
@@ -13568,156 +13650,156 @@
 			}
 		},
 		"@esbuild/android-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+			"integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+			"integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+			"integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+			"integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+			"integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+			"integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+			"integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+			"integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+			"integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+			"integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+			"integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-mips64el": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+			"integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ppc64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+			"integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-riscv64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+			"integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-s390x": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+			"integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+			"integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/netbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/openbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/sunos-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+			"integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+			"integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+			"integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+			"integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -13777,16 +13859,16 @@
 			"dev": true
 		},
 		"@graphql-codegen/cli": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-4.0.1.tgz",
-			"integrity": "sha512-/H4imnGOl3hoPXLKmIiGUnXpmBmeIClSZie/YHDzD5N59cZlGGJlIOOrUlOTDpJx5JNU1MTQcRjyTToOYM5IfA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.0.tgz",
+			"integrity": "sha512-A7J7+be/a6e+/ul2KI5sfJlpoqeqwX8EzktaKCeduyVKgOLA6W5t+NUGf6QumBDXU8PEOqXk3o3F+RAwCWOiqA==",
 			"dev": true,
 			"requires": {
 				"@babel/generator": "^7.18.13",
 				"@babel/template": "^7.18.10",
 				"@babel/types": "^7.18.13",
 				"@graphql-codegen/core": "^4.0.0",
-				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/plugin-helpers": "^5.0.1",
 				"@graphql-tools/apollo-engine-loader": "^8.0.0",
 				"@graphql-tools/code-file-loader": "^8.0.0",
 				"@graphql-tools/git-loader": "^8.0.0",
@@ -13797,7 +13879,6 @@
 				"@graphql-tools/prisma-loader": "^8.0.0",
 				"@graphql-tools/url-loader": "^8.0.0",
 				"@graphql-tools/utils": "^10.0.0",
-				"@parcel/watcher": "^2.1.0",
 				"@whatwg-node/fetch": "^0.8.0",
 				"chalk": "^4.1.0",
 				"cosmiconfig": "^8.1.3",
@@ -13815,7 +13896,7 @@
 				"string-env-interpolation": "^1.0.1",
 				"ts-log": "^2.2.3",
 				"tslib": "^2.4.0",
-				"yaml": "^1.10.0",
+				"yaml": "^2.3.1",
 				"yargs": "^17.0.0"
 			},
 			"dependencies": {
@@ -14833,6 +14914,8 @@
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.2.0.tgz",
 			"integrity": "sha512-71S4TF+IMyAn24PK4KSkdKtqJDR3zRzb0HE3yXpacItqTM7XfF2f5q9NEGLEVl0dAaBAGfNwDCjH120y25F6Tg==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"@parcel/watcher-android-arm64": "2.2.0",
 				"@parcel/watcher-darwin-arm64": "2.2.0",
@@ -14855,70 +14938,80 @@
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.2.0.tgz",
 			"integrity": "sha512-nU2wh00CTQT9rr1TIKTjdQ9lAGYpmz6XuKw0nAwAN+S2A5YiD55BK1u+E5WMCT8YOIDe/n6gaj4o/Bi9294SSQ==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-darwin-arm64": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.2.0.tgz",
 			"integrity": "sha512-cJl0UZDcodciy3TDMomoK/Huxpjlkkim3SyMgWzjovHGOZKNce9guLz2dzuFwfObBFCjfznbFMIvAZ5syXotYw==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-darwin-x64": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.2.0.tgz",
 			"integrity": "sha512-QI77zxaGrCV1StKcoRYfsUfmUmvPMPfQrubkBBy5XujV2fwaLgZivQOTQMBgp5K2+E19u1ufpspKXAPqSzpbyg==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-linux-arm-glibc": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.2.0.tgz",
 			"integrity": "sha512-I2GPBcAXazPzabCmfsa3HRRW+MGlqxYd8g8RIueJU+a4o5nyNZDz0CR1cu0INT0QSQXEZV7w6UE8Hz9CF8u3Pg==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-linux-arm64-glibc": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.2.0.tgz",
 			"integrity": "sha512-St5mlfp+2lS9AmgixUqfwJa/DwVmTCJxC1HcOubUTz6YFOKIlkHCeUa1Bxi4E/tR/HSez8+heXHL8HQkJ4Bd8g==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-linux-arm64-musl": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.2.0.tgz",
 			"integrity": "sha512-jS+qfhhoOBVWwMLP65MaG8xdInMK30pPW8wqTCg2AAuVJh5xepMbzkhHJ4zURqHiyY3EiIRuYu4ONJKCxt8iqA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-linux-x64-glibc": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.2.0.tgz",
 			"integrity": "sha512-xJvJ7R2wJdi47WZBFS691RDOWvP1j/IAs3EXaWVhDI8FFITbWrWaln7KoNcR0Y3T+ZwimFY/cfb0PNht1q895g==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-linux-x64-musl": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.2.0.tgz",
 			"integrity": "sha512-D+NMpgr23a+RI5mu8ZPKWy7AqjBOkURFDgP5iIXXEf/K3hm0jJ3ogzi0Ed2237B/CdYREimCgXyeiAlE/FtwyA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-win32-arm64": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.2.0.tgz",
 			"integrity": "sha512-z225cPn3aygJsyVUOWwfyW+fY0Tvk7N3XCOl66qUPFxpbuXeZuiuuJemmtm8vxyqa3Ur7peU/qJxrpC64aeI7Q==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@parcel/watcher-win32-x64": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.2.0.tgz",
 			"integrity": "sha512-JqGW0RJ61BkKx+yYzIURt9s53P7xMVbv0uxYPzAXLBINGaFmkIKSuUPyBVfy8TMbvp93lvF4SPBNDzVRJfvgOw==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@peculiar/asn1-schema": {
 			"version": "2.3.6",
@@ -14979,9 +15072,9 @@
 			}
 		},
 		"@stripe/stripe-js": {
-			"version": "1.54.1",
-			"resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.54.1.tgz",
-			"integrity": "sha512-smEXPu1GKMcAj9g2luT16+oXfg2jAwyc68t2Dm5wdtYl3p8PqQaZEiI8tQmboaQAjgF8pIGma6byz1T1vgmpbA=="
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-2.1.6.tgz",
+			"integrity": "sha512-QSzqQIcowgap7a40f3a7oUR+59Xet/i8fp1EsnzzwxK5oPRQsCbbLQ4Cd6qM0y1pdZMonFnCrAWayWdE9Lr0iA=="
 		},
 		"@tailwindcss/forms": {
 			"version": "0.5.4",
@@ -15024,9 +15117,9 @@
 			}
 		},
 		"@types/braintree-web-drop-in": {
-			"version": "1.34.3",
-			"resolved": "https://registry.npmjs.org/@types/braintree-web-drop-in/-/braintree-web-drop-in-1.34.3.tgz",
-			"integrity": "sha512-as0s8S1KFLMuMd7rJfogm3dky/7QMfh9Mw6k9XmnMYpJIck+6mVW/WGGkd8MAgYfDzFtAHLT/vjazRzmI9sNSg==",
+			"version": "1.39.1",
+			"resolved": "https://registry.npmjs.org/@types/braintree-web-drop-in/-/braintree-web-drop-in-1.39.1.tgz",
+			"integrity": "sha512-gvFOvQhtRb3nmsKzPBd32oEdqQq6DeCdlm4xLRqe8QpGblIKaEi4MIaU/pCNTxaVyYlIFMiUAO2H2xFyvejtgQ==",
 			"dev": true,
 			"requires": {
 				"@types/applepayjs": "*",
@@ -15045,9 +15138,9 @@
 			}
 		},
 		"@types/eslint": {
-			"version": "8.40.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
-			"integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
+			"version": "8.44.2",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
+			"integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -15130,9 +15223,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "20.4.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-			"integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+			"integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==",
 			"dev": true
 		},
 		"@types/paypal-checkout-components": {
@@ -15142,9 +15235,9 @@
 			"dev": true
 		},
 		"@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
 			"dev": true
 		},
 		"@types/unist": {
@@ -15163,102 +15256,103 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz",
-			"integrity": "sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
+			"integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
 			"dev": true,
 			"requires": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.61.0",
-				"@typescript-eslint/type-utils": "5.61.0",
-				"@typescript-eslint/utils": "5.61.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.4.0",
+				"@typescript-eslint/type-utils": "6.4.0",
+				"@typescript-eslint/utils": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.61.0.tgz",
-			"integrity": "sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+			"integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.61.0",
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/typescript-estree": "5.61.0",
+				"@typescript-eslint/scope-manager": "6.4.0",
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/typescript-estree": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
-			"integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+			"integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/visitor-keys": "5.61.0"
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.61.0.tgz",
-			"integrity": "sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
+			"integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "5.61.0",
-				"@typescript-eslint/utils": "5.61.0",
+				"@typescript-eslint/typescript-estree": "6.4.0",
+				"@typescript-eslint/utils": "6.4.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
-			"integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+			"integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
-			"integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+			"integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/visitor-keys": "5.61.0",
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/visitor-keys": "6.4.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.61.0.tgz",
-			"integrity": "sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
+			"integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
 			"dev": true,
 			"requires": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.61.0",
-				"@typescript-eslint/types": "5.61.0",
-				"@typescript-eslint/typescript-estree": "5.61.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.4.0",
+				"@typescript-eslint/types": "6.4.0",
+				"@typescript-eslint/typescript-estree": "6.4.0",
+				"semver": "^7.5.4"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
-			"integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+			"integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.61.0",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "6.4.0",
+				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
 		"@whatwg-node/events": {
@@ -15502,13 +15596,13 @@
 			"integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ=="
 		},
 		"autoprefixer": {
-			"version": "10.4.14",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-			"integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+			"version": "10.4.15",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+			"integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.21.5",
-				"caniuse-lite": "^1.0.30001464",
+				"browserslist": "^4.21.10",
+				"caniuse-lite": "^1.0.30001520",
 				"fraction.js": "^4.2.0",
 				"normalize-range": "^0.1.2",
 				"picocolors": "^1.0.0",
@@ -15584,13 +15678,13 @@
 			"dev": true
 		},
 		"better-sqlite3": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.5.0.tgz",
-			"integrity": "sha512-vbPcv/Hx5WYdyNg/NbcfyaBZyv9s/NVbxb7yCeC5Bq1pVocNxeL2tZmSu3Rlm4IEOTjYdGyzWQgyx0OSdORBzw==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.6.0.tgz",
+			"integrity": "sha512-jwAudeiTMTSyby+/SfbHDebShbmC2MCH8mU2+DXi0WJfv13ypEJm47cd3kljmy/H130CazEvkf2Li//ewcMJ1g==",
 			"dev": true,
 			"requires": {
 				"bindings": "^1.5.0",
-				"prebuild-install": "^7.1.0"
+				"prebuild-install": "^7.1.1"
 			}
 		},
 		"binary-extensions": {
@@ -15648,16 +15742,16 @@
 			}
 		},
 		"braintree-web": {
-			"version": "3.96.1",
-			"resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.96.1.tgz",
-			"integrity": "sha512-e483TQkRmcO5zFH+pMGUokFWq5Q+Jyn9TmUIDofPpul1P+xOciwNqvekl/Ku6MsJBT1+kyH0cndBYMZVJpbrtg==",
+			"version": "3.97.1",
+			"resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.97.1.tgz",
+			"integrity": "sha512-9f9yNoC+vS9RGrkAaE80BbyX4L1JE9j+ZzgT66MxiU6011J6Bs3E+iLtXodi2bpFTRlBlT0F4GIW5kHT7RC6bQ==",
 			"requires": {
 				"@braintree/asset-loader": "0.4.4",
-				"@braintree/browser-detection": "1.14.0",
+				"@braintree/browser-detection": "1.17.1",
 				"@braintree/event-emitter": "0.4.1",
 				"@braintree/extended-promise": "0.4.1",
 				"@braintree/iframer": "1.1.0",
-				"@braintree/sanitize-url": "6.0.2",
+				"@braintree/sanitize-url": "6.0.4",
 				"@braintree/uuid": "0.1.0",
 				"@braintree/wrap-promise": "2.1.0",
 				"card-validator": "8.1.1",
@@ -15668,6 +15762,11 @@
 				"restricted-input": "3.0.5"
 			},
 			"dependencies": {
+				"@braintree/browser-detection": {
+					"version": "1.17.1",
+					"resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.17.1.tgz",
+					"integrity": "sha512-Mk7jauyp9pD14BTRS7otoy9dqIJGb3Oy0XtxKM/adGD9i9MAuCjH5uRZMyW2iVmJQTaA/PLlWdG7eSDyMWMc8Q=="
+				},
 				"promise-polyfill": {
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
@@ -15676,27 +15775,27 @@
 			}
 		},
 		"braintree-web-drop-in": {
-			"version": "1.39.1",
-			"resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.39.1.tgz",
-			"integrity": "sha512-qpSXoSnT0fhQMmBctv/xntw5MoJgShW9A2p2L29oTteMtwKsPMY5um/VpevbFWibKuNdV1PW+nagzYJDKp61LA==",
+			"version": "1.40.2",
+			"resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.40.2.tgz",
+			"integrity": "sha512-m7sfLevcq/Q16ZGIFPNBbLNrnWEgtUZN939nyrpTd9My7O5v8A+BfqOQePEmBy+wkiWMC33i1Csk5peq69FWVw==",
 			"requires": {
 				"@braintree/asset-loader": "0.4.4",
 				"@braintree/browser-detection": "1.14.0",
 				"@braintree/event-emitter": "0.4.1",
 				"@braintree/uuid": "0.1.0",
 				"@braintree/wrap-promise": "2.1.0",
-				"braintree-web": "3.96.1"
+				"braintree-web": "3.97.1"
 			}
 		},
 		"browserslist": {
-			"version": "4.21.9",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-			"integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+			"version": "4.21.11",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.11.tgz",
+			"integrity": "sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001503",
-				"electron-to-chromium": "^1.4.431",
-				"node-releases": "^2.0.12",
-				"update-browserslist-db": "^1.0.11"
+				"caniuse-lite": "^1.0.30001538",
+				"electron-to-chromium": "^1.4.526",
+				"node-releases": "^2.0.13",
+				"update-browserslist-db": "^1.0.13"
 			}
 		},
 		"bser": {
@@ -15727,6 +15826,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
 			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dev": true,
 			"requires": {
 				"streamsearch": "^1.1.0"
 			}
@@ -15768,9 +15868,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001517",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-			"integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA=="
+			"version": "1.0.30001539",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz",
+			"integrity": "sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA=="
 		},
 		"capital-case": {
 			"version": "1.0.4",
@@ -16358,7 +16458,9 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"didyoumean": {
 			"version": "1.2.2",
@@ -16455,9 +16557,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.477",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz",
-			"integrity": "sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw=="
+			"version": "1.4.529",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.529.tgz",
+			"integrity": "sha512-6uyPyXTo8lkv8SWAmjKFbG42U073TXlzD4R8rW3EzuznhFS2olCIAfjjQtV2dV2ar/vRF55KUd3zQYnCB0dd3A=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -16567,33 +16669,33 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+			"integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
 			"dev": true,
 			"requires": {
-				"@esbuild/android-arm": "0.17.19",
-				"@esbuild/android-arm64": "0.17.19",
-				"@esbuild/android-x64": "0.17.19",
-				"@esbuild/darwin-arm64": "0.17.19",
-				"@esbuild/darwin-x64": "0.17.19",
-				"@esbuild/freebsd-arm64": "0.17.19",
-				"@esbuild/freebsd-x64": "0.17.19",
-				"@esbuild/linux-arm": "0.17.19",
-				"@esbuild/linux-arm64": "0.17.19",
-				"@esbuild/linux-ia32": "0.17.19",
-				"@esbuild/linux-loong64": "0.17.19",
-				"@esbuild/linux-mips64el": "0.17.19",
-				"@esbuild/linux-ppc64": "0.17.19",
-				"@esbuild/linux-riscv64": "0.17.19",
-				"@esbuild/linux-s390x": "0.17.19",
-				"@esbuild/linux-x64": "0.17.19",
-				"@esbuild/netbsd-x64": "0.17.19",
-				"@esbuild/openbsd-x64": "0.17.19",
-				"@esbuild/sunos-x64": "0.17.19",
-				"@esbuild/win32-arm64": "0.17.19",
-				"@esbuild/win32-ia32": "0.17.19",
-				"@esbuild/win32-x64": "0.17.19"
+				"@esbuild/android-arm": "0.18.20",
+				"@esbuild/android-arm64": "0.18.20",
+				"@esbuild/android-x64": "0.18.20",
+				"@esbuild/darwin-arm64": "0.18.20",
+				"@esbuild/darwin-x64": "0.18.20",
+				"@esbuild/freebsd-arm64": "0.18.20",
+				"@esbuild/freebsd-x64": "0.18.20",
+				"@esbuild/linux-arm": "0.18.20",
+				"@esbuild/linux-arm64": "0.18.20",
+				"@esbuild/linux-ia32": "0.18.20",
+				"@esbuild/linux-loong64": "0.18.20",
+				"@esbuild/linux-mips64el": "0.18.20",
+				"@esbuild/linux-ppc64": "0.18.20",
+				"@esbuild/linux-riscv64": "0.18.20",
+				"@esbuild/linux-s390x": "0.18.20",
+				"@esbuild/linux-x64": "0.18.20",
+				"@esbuild/netbsd-x64": "0.18.20",
+				"@esbuild/openbsd-x64": "0.18.20",
+				"@esbuild/sunos-x64": "0.18.20",
+				"@esbuild/win32-arm64": "0.18.20",
+				"@esbuild/win32-ia32": "0.18.20",
+				"@esbuild/win32-x64": "0.18.20"
 			}
 		},
 		"escalade": {
@@ -16607,9 +16709,9 @@
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 		},
 		"eslint": {
-			"version": "8.44.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-			"integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+			"version": "8.45.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+			"integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
@@ -16637,7 +16739,6 @@
 				"globals": "^13.19.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
@@ -16649,7 +16750,6 @@
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
@@ -16751,22 +16851,12 @@
 			}
 		},
 		"eslint-plugin-qwik": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qwik/-/eslint-plugin-qwik-1.2.4.tgz",
-			"integrity": "sha512-4bckfkFLYaJ0ngVBsUQPukr/lazShZ/dSKf3zm+UzBPJSpPdFOElXdPJAwAgEGvFobpMWsWFEhas1LN144YFAw==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qwik/-/eslint-plugin-qwik-1.2.11.tgz",
+			"integrity": "sha512-F4h4waCC9g8cXREVgHLhUzlbPkKJ7TpuUd1xmFQ0D+vYXvKk7RYYC1azBZMXqcc09b8XXz1UuvR2HLMrf/JblQ==",
 			"dev": true,
 			"requires": {
 				"jsx-ast-utils": "^3.3.4"
-			}
-		},
-		"eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"requires": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -16819,12 +16909,6 @@
 					"dev": true
 				}
 			}
-		},
-		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
 		},
 		"estree-util-attach-comments": {
 			"version": "2.1.1",
@@ -17324,9 +17408,9 @@
 			"dev": true
 		},
 		"graphql": {
-			"version": "16.7.1",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-			"integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg=="
+			"version": "16.8.1",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+			"integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw=="
 		},
 		"graphql-config": {
 			"version": "5.0.2",
@@ -18875,9 +18959,9 @@
 			"dev": true
 		},
 		"miniflare": {
-			"version": "3.20230724.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230724.0.tgz",
-			"integrity": "sha512-YU8yUwoVJCiuzY2i9ZBJ+McjL/mqwKnMJfn23QedSCvx82Mys8GAlkHCH69mqSqzlSw8IVcdxec330meRRf9bg==",
+			"version": "3.20230814.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230814.1.tgz",
+			"integrity": "sha512-LMgqd1Ut0+fnlvQepVbbBYQczQnyuuap8bgUwOyPETka0S9NR9NxMQSNaBgVZ0uOaG7xMJ/OVTRlz+TGB86PWA==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
@@ -18892,7 +18976,7 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "1.20230724.0",
+				"workerd": "1.20230814.1",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
@@ -18983,12 +19067,6 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"no-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -19011,7 +19089,9 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
 			"integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node-domexception": {
 			"version": "1.0.0",
@@ -19020,9 +19100,9 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"dev": true,
 			"requires": {
 				"data-uri-to-buffer": "^4.0.0",
@@ -19418,9 +19498,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.24",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-			"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+			"version": "8.4.28",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+			"integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
 			"dev": true,
 			"requires": {
 				"nanoid": "^3.3.6",
@@ -19456,14 +19536,6 @@
 			"requires": {
 				"lilconfig": "^2.0.5",
 				"yaml": "^2.1.1"
-			},
-			"dependencies": {
-				"yaml": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-					"integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-					"dev": true
-				}
 			}
 		},
 		"postcss-nested": {
@@ -19926,9 +19998,9 @@
 			}
 		},
 		"rollup": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.0.tgz",
-			"integrity": "sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==",
+			"version": "3.29.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.3.tgz",
+			"integrity": "sha512-T7du6Hum8jOkSWetjRgbwpM6Sy0nECYrYRSmZjayFcOddtKJWU4d17AC3HNUk7HRuqy4p+G7aEZclSHytqUmEg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -20344,7 +20416,8 @@
 		"streamsearch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"dev": true
 		},
 		"streamx": {
 			"version": "2.15.0",
@@ -20527,9 +20600,9 @@
 			}
 		},
 		"tailwindcss": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
-			"integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
+			"integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
 			"dev": true,
 			"requires": {
 				"@alloc/quick-lru": "^5.2.0",
@@ -20552,7 +20625,6 @@
 				"postcss-load-config": "^4.0.1",
 				"postcss-nested": "^6.0.1",
 				"postcss-selector-parser": "^6.0.11",
-				"postcss-value-parser": "^4.2.0",
 				"resolve": "^1.22.2",
 				"sucrase": "^3.32.0"
 			},
@@ -20673,6 +20745,13 @@
 			"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
 			"dev": true
 		},
+		"ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"requires": {}
+		},
 		"ts-interface-checker": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -20696,23 +20775,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
 			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-		},
-		"tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.8.1"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
-				}
-			}
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -20813,9 +20875,10 @@
 			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg=="
 		},
 		"undici": {
-			"version": "5.22.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-			"integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+			"version": "5.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+			"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"
 			}
@@ -20929,9 +20992,9 @@
 			}
 		},
 		"update-browserslist-db": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
 			"requires": {
 				"escalade": "^3.1.1",
 				"picocolors": "^1.0.0"
@@ -21023,15 +21086,15 @@
 			}
 		},
 		"vite": {
-			"version": "4.3.9",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
-			"integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+			"integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.17.5",
+				"esbuild": "^0.18.10",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.23",
-				"rollup": "^3.21.0"
+				"postcss": "^8.4.27",
+				"rollup": "^3.27.1"
 			}
 		},
 		"vite-imagetools": {
@@ -21138,22 +21201,22 @@
 			}
 		},
 		"workerd": {
-			"version": "1.20230724.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230724.0.tgz",
-			"integrity": "sha512-++D7JqS4/dk7zvtGpk+i/7G9bZtEl6lTtgAsIoSSGR1qJAxxEu21ktm9+FH0EYh7uKfizuM5H9lrTsR+3u44PA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
+			"integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
 			"dev": true,
 			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20230724.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230724.0",
-				"@cloudflare/workerd-linux-64": "1.20230724.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230724.0",
-				"@cloudflare/workerd-windows-64": "1.20230724.0"
+				"@cloudflare/workerd-darwin-64": "1.20230814.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20230814.1",
+				"@cloudflare/workerd-linux-64": "1.20230814.1",
+				"@cloudflare/workerd-linux-arm64": "1.20230814.1",
+				"@cloudflare/workerd-windows-64": "1.20230814.1"
 			}
 		},
 		"wrangler": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.4.0.tgz",
-			"integrity": "sha512-sATQ84zH/zFUHSaa4hY3V24TBrad3R9HhGV47U6Ek7XRQDLQHBm0jt84mJD3sSV/hhaq5s+xidIYulhm+m1/Tg==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.5.1.tgz",
+			"integrity": "sha512-CnrKId+pmjTfLSidM9Ut7lUDCFWEtJyY3JT3Dk+TgYHvu2zVmMgUeQQZHZfvpVN5eaEZifNQr90KEvMLy7MhHw==",
 			"dev": true,
 			"requires": {
 				"@cloudflare/kv-asset-handler": "^0.2.0",
@@ -21163,7 +21226,7 @@
 				"chokidar": "^3.5.3",
 				"esbuild": "0.16.3",
 				"fsevents": "~2.3.2",
-				"miniflare": "3.20230724.0",
+				"miniflare": "3.20230814.1",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -21419,9 +21482,9 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+			"integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
 			"dev": true
 		},
 		"yaml-ast-parser": {
@@ -21456,9 +21519,9 @@
 			"dev": true
 		},
 		"youch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.2.tgz",
+			"integrity": "sha512-9cwz/z7abtcHOIuH45nzmUFCZbyJA1nLqlirKvyNRx4wDMhqsBaifAJzBej7L4fsVPjFxYq3NK3GAcfvZsydFw==",
 			"dev": true,
 			"requires": {
 				"cookie": "^0.5.0",
@@ -21467,9 +21530,9 @@
 			}
 		},
 		"zod": {
-			"version": "3.21.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-			"integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
+			"version": "3.22.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+			"integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg=="
 		},
 		"zwitch": {
 			"version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
 		"graphql": "^16.8.0",
 		"graphql-tag": "^2.12.6",
 		"qwik-image": "^0.0.7",
-		"undici": "^5.23.0",
 		"zod": "^3.22.1"
 	},
 	"overrides": {


### PR DESCRIPTION
Hi,

This PR is to remove `undici` from dependencies as it's already defined in devDependencies and not needed in prod.
The duplication is causing `bun install` to fail.

The package is used for @builder.io/qwik@ and wrangler@ which both are devDependencies

Thanks for the awesome work!