### PR TITLE
fix: use env variable for apis

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
-VITE_VENDURE_PUBLIC_URL=https://readonlydemo.vendure.io/shop-api
-VITE_VENDURE_LOCAL_URL=http://localhost:3000/shop-api
+VITE_VENDURE_PROD_URL=https://readonlydemo.vendure.io
+VITE_VENDURE_DEV_URL=https://readonlydemo.vendure.io
+VITE_VENDURE_LOCAL_URL=http://localhost:3000
 VITE_SHOW_PAYMENT_STEP=true
 VITE_SHOW_REVIEWS=true
 VITE_SECURE_COOKIE=true

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import { createContextId } from '@builder.io/qwik';
+import { ENV_VARIABLES } from '~/env';
 import { AppState } from './types';
 
 export const APP_STATE = createContextId<AppState>('app_state');
@@ -13,7 +14,6 @@ export const DEFAULT_METADATA_DESCRIPTION =
 	'A headless commerce storefront starter kit built with Vendure & Qwik';
 export const DEFAULT_METADATA_IMAGE = 'https://qwik-storefront.vendure.io/social-image.png';
 export const DEFAULT_LOCALE = 'en';
-// TODO: replace DEV_API and PROD_API with your dev and prod API urls.
-export const DEV_API = 'https://readonlydemo.vendure.io';
-export const PROD_API = 'https://readonlydemo.vendure.io';
-export const LOCAL_API = 'http://localhost:3000';
+export const DEV_API = ENV_VARIABLES.VITE_VENDURE_DEV_URL || 'https://readonlydemo.vendure.io';
+export const PROD_API = ENV_VARIABLES.VITE_VENDURE_PROD_URL || 'https://readonlydemo.vendure.io';
+export const LOCAL_API = ENV_VARIABLES.VITE_VENDURE_LOCAL_URL || 'http://localhost:3000';

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,8 +1,9 @@
 import z from 'zod';
 
 const envVariables = z.object({
-	VITE_VENDURE_PUBLIC_URL: z.string(),
+	VITE_VENDURE_PROD_URL: z.string(),
 	VITE_VENDURE_LOCAL_URL: z.string(),
+	VITE_VENDURE_DEV_URL: z.string(),
 	VITE_SHOW_PAYMENT_STEP: z.string(),
 	VITE_SHOW_REVIEWS: z.string(),
 	VITE_SECURE_COOKIE: z.string(),


### PR DESCRIPTION
This PR
* fixes #161 
* uses env variable for api urls if available
* adds env variable `VITE_VENDURE_DEV_URL`
